### PR TITLE
fix issue #60: limit maxHeight of popup to 80% of map's height

### DIFF
--- a/hu/index.html
+++ b/hu/index.html
@@ -119,7 +119,7 @@
                             <a href="https://wiki.openstreetmap.org/wiki/DE:Tag:craft%3Dbeekeeper" target="_blank" rel="noopener">craft=beekeeper</a> für Imker</p>
     
 
-                        <p>Von all diesen Orten werden - falls vorhanden - alle weiteren Daten wie die Adresse oder die Öfnungszeiten
+                        <p>Von all diesen Orten werden - falls vorhanden - alle weiteren Daten wie die Adresse oder die Öffnungszeiten
                         im Popup angezeigt, wobei unbekannte Tags in der Tabelle landen und teilweise Begriffe übersetzt werden.</p>
                     <p>Folgende Tags werden im Popup formatiert dargestellt:</p>
 
@@ -127,7 +127,7 @@
                         <img src="img/popupbeispiel.png" style="width:100%; max-width: 300px;" alt=""> </p>
 
                     <br>
-                    Öffnungszeiten werden im <a href="https://wiki.openstreetmap.org/wiki/DE:Key:opening_hours#.C3.96ffnungszeiten_f.C3.BCr_Ulm.2C_Neu-Ulm_.26_Umgebung" target="_blank" rel="noopener">OpenStreetMap-Format</a> angezeigt. Darunter findet man einen grünen oder roten Text der angibt, ob die Einrichtung im Moment offen oder geschlossen ist. Jedoch werden Öffnungszeiten momentan nur ausgewertet, wenn sie keine (länderspezifischen) Schulferien enthalten.
+                    Öffnungszeiten werden im <a href="https://wiki.openstreetmap.org/wiki/DE:Key:opening_hours#.C3.96ffnungszeiten_f.C3.BCr_Ulm.2C_Neu-Ulm_.26_Umgebung" target="_blank" rel="noopener">OpenStreetMap-Format</a> angezeigt. Darunter findet man einen grünen oder roten Text, der angibt, ob die Einrichtung im Moment offen oder geschlossen ist. Jedoch werden Öffnungszeiten momentan nur ausgewertet, wenn sie keine (länderspezifischen) Schulferien enthalten.
                 </p>
                 <p>
                     <h3>Wie häufig werden die Daten abgeglichen und welchen Stand haben sie jetzt gerade?</h3>
@@ -201,7 +201,7 @@
                         <li>Das Markt-Icon wurde von İsmail Nural erstellt
                             <a href="https://thenounproject.com/icon/195153/#">Mehr Informationen zum Icon bei the noun project </a>
                         </li>
-                        <li>Das Imnker-Icon wurde von Mello erstellt
+                        <li>Das Imker-Icon wurde von Mello erstellt
                             <a href="https://thenounproject.com/icon/2093276/#">Mehr Informationen zum Icon bei the noun project </a>
                         </li>
                     </ul>

--- a/hu/js/direktvermarkter.js
+++ b/hu/js/direktvermarkter.js
@@ -75,13 +75,20 @@ var geojson1 = L.geoJson(farmshopGeoJson, {
 
     onEachFeature: function onEachFeature(feature, layer) {
         layer.once("click", function () {
-            divmap = document.getElementById('map');
             $.getJSON('data/' + feature.properties.id + '/details.json', function (data) {
-                layer.bindPopup(popupcontent(data, layer), {maxHeight: 0.8*divmap.offsetHeight, maxWidth: 0.95*divmap.offsetWidth}).openPopup();
+                layer.bindPopup(popupcontent(data, layer)).openPopup();
             });
         });
     }
 }).addLayer(tiles);
+
+map.on('popupopen', function (e) {
+  // resize popups to current map size to avoid overflows
+  var divmap = document.getElementById('map');
+  e.popup.options.maxHeight = 0.8 * divmap.offsetHeight;
+  e.popup.options.maxWidth = 0.95 * divmap.offsetWidth;
+  e.popup.update();
+});
 
 //Changing Cluster radius based on zoom level
 var GetClusterRadius = function (zoom) { 

--- a/hu/js/direktvermarkter.js
+++ b/hu/js/direktvermarkter.js
@@ -75,8 +75,9 @@ var geojson1 = L.geoJson(farmshopGeoJson, {
 
     onEachFeature: function onEachFeature(feature, layer) {
         layer.once("click", function () {
+            divmap = document.getElementById('map');
             $.getJSON('data/' + feature.properties.id + '/details.json', function (data) {
-                layer.bindPopup(popupcontent(data, layer), {maxHeight: 0.8*document.getElementById('map').offsetHeight}).openPopup();
+                layer.bindPopup(popupcontent(data, layer), {maxHeight: 0.8*divmap.offsetHeight, maxWidth: 0.95*divmap.offsetWidth}).openPopup();
             });
         });
     }

--- a/hu/js/direktvermarkter.js
+++ b/hu/js/direktvermarkter.js
@@ -76,7 +76,7 @@ var geojson1 = L.geoJson(farmshopGeoJson, {
     onEachFeature: function onEachFeature(feature, layer) {
         layer.once("click", function () {
             $.getJSON('data/' + feature.properties.id + '/details.json', function (data) {
-                layer.bindPopup(popupcontent(data, layer)).openPopup();
+                layer.bindPopup(popupcontent(data, layer), {maxHeight: 0.8*document.getElementById('map').offsetHeight}).openPopup();
             });
         });
     }

--- a/hu/js/popupcontent.js
+++ b/hu/js/popupcontent.js
@@ -20,7 +20,7 @@ function popupcontent(feature, layer) {
             popupcontent.push("<tr><td><strong>"
                 + prop.replace("fixme", "Unklare Daten") + ":</strong> </td><td>"
                 + feature.properties[prop].replace("position estimated", "Position geschätzt")
-                + " <a target='_blank' rel='noopener' href='http://openstreetmap.org/" + feature.id + "'> Daten Verbessern</a>");
+                + " <a target='_blank' rel='noopener' href='http://openstreetmap.org/" + feature.id + "'> Daten verbessern</a>");
             console.log(prop + " " + feature.properties[prop] + " (fixme)");
         }
         else if (prop == "email" || prop == "contact:email") {

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
                             <a href="https://wiki.openstreetmap.org/wiki/DE:Tag:craft%3Dbeekeeper" target="_blank" rel="noopener">craft=beekeeper</a> für Imker</p>
     
 
-                        <p>Von all diesen Orten werden - falls vorhanden - alle weiteren Daten wie die Adresse oder die Öfnungszeiten
+                        <p>Von all diesen Orten werden - falls vorhanden - alle weiteren Daten wie die Adresse oder die Öffnungszeiten
                         im Popup angezeigt, wobei unbekannte Tags in der Tabelle landen und teilweise Begriffe übersetzt werden.</p>
                     <p>Folgende Tags werden im Popup formatiert dargestellt:</p>
 
@@ -127,7 +127,7 @@
                         <img src="img/popupbeispiel.png" style="width:100%; max-width: 300px;" alt=""> </p>
 
                     <br>
-                    Öffnungszeiten werden im <a href="https://wiki.openstreetmap.org/wiki/DE:Key:opening_hours#.C3.96ffnungszeiten_f.C3.BCr_Ulm.2C_Neu-Ulm_.26_Umgebung" target="_blank" rel="noopener">OpenStreetMap-Format</a> angezeigt. Darunter findet man einen grünen oder roten Text der angibt, ob die Einrichtung im Moment offen oder geschlossen ist. Jedoch werden Öffnungszeiten momentan nur ausgewertet, wenn sie keine (länderspezifischen) Schulferien enthalten.
+                    Öffnungszeiten werden im <a href="https://wiki.openstreetmap.org/wiki/DE:Key:opening_hours#.C3.96ffnungszeiten_f.C3.BCr_Ulm.2C_Neu-Ulm_.26_Umgebung" target="_blank" rel="noopener">OpenStreetMap-Format</a> angezeigt. Darunter findet man einen grünen oder roten Text, der angibt, ob die Einrichtung im Moment offen oder geschlossen ist. Jedoch werden Öffnungszeiten momentan nur ausgewertet, wenn sie keine (länderspezifischen) Schulferien enthalten.
                 </p>
                 <p>
                     <h3>Wie häufig werden die Daten abgeglichen und welchen Stand haben sie jetzt gerade?</h3>
@@ -201,7 +201,7 @@
                         <li>Das Markt-Icon wurde von İsmail Nural erstellt
                             <a href="https://thenounproject.com/icon/195153/#">Mehr Informationen zum Icon bei the noun project </a>
                         </li>
-                        <li>Das Imnker-Icon wurde von Mello erstellt
+                        <li>Das Imker-Icon wurde von Mello erstellt
                             <a href="https://thenounproject.com/icon/2093276/#">Mehr Informationen zum Icon bei the noun project </a>
                         </li>
                     </ul>

--- a/js/direktvermarkter.js
+++ b/js/direktvermarkter.js
@@ -75,13 +75,20 @@ var geojson1 = L.geoJson(farmshopGeoJson, {
 
     onEachFeature: function onEachFeature(feature, layer) {
         layer.once("click", function () {
-            divmap = document.getElementById('map');
             $.getJSON('data/' + feature.properties.id + '/details.json', function (data) {
-                layer.bindPopup(popupcontent(data, layer), {maxHeight: 0.8*divmap.offsetHeight, maxWidth: 0.95*divmap.offsetWidth}).openPopup();
+                layer.bindPopup(popupcontent(data, layer)).openPopup();
             });
         });
     }
 }).addLayer(tiles);
+
+map.on('popupopen', function (e) {
+  // resize popups to current map size to avoid overflows
+  var divmap = document.getElementById('map');
+  e.popup.options.maxHeight = 0.8 * divmap.offsetHeight;
+  e.popup.options.maxWidth = 0.95 * divmap.offsetWidth;
+  e.popup.update();
+});
 
 //Changing Cluster radius based on zoom level
 var GetClusterRadius = function (zoom) { 

--- a/js/direktvermarkter.js
+++ b/js/direktvermarkter.js
@@ -75,8 +75,9 @@ var geojson1 = L.geoJson(farmshopGeoJson, {
 
     onEachFeature: function onEachFeature(feature, layer) {
         layer.once("click", function () {
+            divmap = document.getElementById('map');
             $.getJSON('data/' + feature.properties.id + '/details.json', function (data) {
-                layer.bindPopup(popupcontent(data, layer), {maxHeight: 0.8*document.getElementById('map').offsetHeight}).openPopup();
+                layer.bindPopup(popupcontent(data, layer), {maxHeight: 0.8*divmap.offsetHeight, maxWidth: 0.95*divmap.offsetWidth}).openPopup();
             });
         });
     }

--- a/js/direktvermarkter.js
+++ b/js/direktvermarkter.js
@@ -76,7 +76,7 @@ var geojson1 = L.geoJson(farmshopGeoJson, {
     onEachFeature: function onEachFeature(feature, layer) {
         layer.once("click", function () {
             $.getJSON('data/' + feature.properties.id + '/details.json', function (data) {
-                layer.bindPopup(popupcontent(data, layer)).openPopup();
+                layer.bindPopup(popupcontent(data, layer), {maxHeight: 0.8*document.getElementById('map').offsetHeight}).openPopup();
             });
         });
     }

--- a/js/popupcontent.js
+++ b/js/popupcontent.js
@@ -20,7 +20,7 @@ function popupcontent(feature, layer) {
             popupcontent.push("<tr><td><strong>"
                 + prop.replace("fixme", "Unklare Daten") + ":</strong> </td><td>"
                 + feature.properties[prop].replace("position estimated", "Position geschätzt")
-                + " <a target='_blank' rel='noopener' href='http://openstreetmap.org/" + feature.id + "'> Daten Verbessern</a>");
+                + " <a target='_blank' rel='noopener' href='http://openstreetmap.org/" + feature.id + "'> Daten verbessern</a>");
             console.log(prop + " " + feature.properties[prop] + " (fixme)");
         }
         else if (prop == "email" || prop == "contact:email") {


### PR DESCRIPTION
The fix reduces the maximum height of a popup to 80 percent of the available height of the map to resolve #60. If map's height is larger, the popup will only consume a height which it needs to display its content, i.e. it is not stretched to 80 percent of the map's height.
Furthermore, some typos are fixed.

The mobile device simulation in recent desktop browsers shows how the popup's height is now limited to properly display on the small screen. Scrollbars inside the popup allow to see the whole content nevertheless.
![maxHeight_of_popup_limited_to_80_percent_of_screen_height](https://user-images.githubusercontent.com/94784984/210902678-e8fcc5fb-6c1b-482f-b2f4-f6dbb605cbf5.gif)
